### PR TITLE
css: avoid spilling mime type in multiple lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,9 @@
                 font-family: sans-serif;
                 hyphens: auto;
             }
+            code {
+                hyphens: none;
+            }
             .light { display: none; }
             .dark { display: block; }
             @media screen and (prefers-color-scheme: light) {


### PR DESCRIPTION
hyphens rule get applied to code blocks in firefox for some reason.
This makes sure that this doesn't happen.